### PR TITLE
v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=master)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cludtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
+# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=master)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
 
 CloudTag is a Curator's `EnsembleProvider` implementation which returns a connection string based on cloud servers with matching tags.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-<<<<<<< Updated upstream
-# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=refactoring-and-extended-test-coverage)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
-=======
-# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=refactoring-and-extended-test-coverage)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cludtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
->>>>>>> Stashed changes
+# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=master)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cludtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
+
 CloudTag is a Curator's `EnsembleProvider` implementation which returns a connection string based on cloud servers with matching tags.
 
 The idea is simple, CloudTag lists all nodes in your cloud and, based on tag name and its value, filters nodes which
@@ -47,8 +44,6 @@ but just in case, please mind that jclouds' `UserMetaData` is mapped to differen
 
 In theory every jclouds provider will work with CloudTag, but I didn't test them all.
 
-<<<<<<< Updated upstream
-=======
 # Test/dev/local provider
 
 You can also setup CloudTag for a test/dev/local environment using a single server provider configuration:
@@ -63,7 +58,6 @@ cloudtaq.singleServer.address=192.168.99.100
 cloudtag.singleServer.port=32773
 ```
 
->>>>>>> Stashed changes
 # EnsembleProvider implementations
 
 There are two Curator's `EnsembleProvider` implementations:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 # CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=refactoring-and-extended-test-coverage)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
+=======
+# CloudTag [![Build Status](https://travis-ci.org/lukaszbudnik/cloudtag.svg?branch=refactoring-and-extended-test-coverage)](https://travis-ci.org/lukaszbudnik/cloudtag) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cludtag/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/com.github.lukaszbudnik.cloudtag/cloudtag)
+>>>>>>> Stashed changes
 CloudTag is a Curator's `EnsembleProvider` implementation which returns a connection string based on cloud servers with matching tags.
 
 The idea is simple, CloudTag lists all nodes in your cloud and, based on tag name and its value, filters nodes which
@@ -43,6 +47,23 @@ but just in case, please mind that jclouds' `UserMetaData` is mapped to differen
 
 In theory every jclouds provider will work with CloudTag, but I didn't test them all.
 
+<<<<<<< Updated upstream
+=======
+# Test/dev/local provider
+
+You can also setup CloudTag for a test/dev/local environment using a single server provider configuration:
+
+```
+cloudtag.provider=single-server
+cloudtag.identity=ignored
+cloudtag.credential=ignored
+cloudtag.tagName=ignored
+cloudtag.tagValue=ignored
+cloudtaq.singleServer.address=192.168.99.100
+cloudtag.singleServer.port=32773
+```
+
+>>>>>>> Stashed changes
 # EnsembleProvider implementations
 
 There are two Curator's `EnsembleProvider` implementations:

--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,16 @@ task javadocJar(type: Jar) {
 }
 
 task printTestErrors {
-    def xmlReports = new File("${buildDir}/test-results")
-    if (xmlReports.exists()) {
-        xmlReports.eachFileMatch(groovy.io.FileType.FILES, ~/TEST\-.*\.xml/) {
-            def testsuite = new groovy.util.XmlParser().parse(it)
-            testsuite.testcase.findAll {
-                it.failure.size() > 0
-            }.each {
-                println it
+    if (System.getenv().containsKey("TRAVIS")) {
+        def xmlReports = new File("${buildDir}/test-results")
+        if (xmlReports.exists()) {
+            xmlReports.eachFileMatch(groovy.io.FileType.FILES, ~/TEST\-.*\.xml/) {
+                def testsuite = new groovy.util.XmlParser().parse(it)
+                testsuite.testcase.findAll {
+                    it.failure.size() > 0
+                }.each {
+                    println it
+                }
             }
         }
     }
@@ -96,7 +98,7 @@ uploadArchives {
                 packaging 'jar'
                 // optionally artifactId can be defined here
                 description 'CloudTag is a Curator ensemble provider which returns connection string based on cloud servers with matching tags.'
-                url 'https://github.com/lukaszbudnik/jelvis'
+                url 'https://github.com/lukaszbudnik/cloudtag'
 
                 scm {
                     connection 'scm:git:git@github.com:lukaszbudnik/cloudtag.git'

--- a/src/main/java/com/github/lukaszbudnik/cloudtag/Configuration.java
+++ b/src/main/java/com/github/lukaszbudnik/cloudtag/Configuration.java
@@ -17,6 +17,7 @@ import javax.inject.Singleton;
 @Singleton
 public class Configuration {
 
+    public static final String SINGLE_SERVER_PROVIDER = "single-server";
     public static final Boolean DEFAULT_USE_PUBLIC_IP = Boolean.FALSE;
     public static final Integer DEFAULT_ZOOKEEPER_PORT = 2181;
     public static final Integer DEFAULT_ASYNC_INTERVAL_SECONDS = 60;
@@ -61,9 +62,21 @@ public class Configuration {
     @Named("cloudtag.asyncIntervalSeconds")
     private Integer asyncIntervalSeconds = DEFAULT_ASYNC_INTERVAL_SECONDS;
 
+    @Inject(optional = true)
+    @Named("cloudtaq.singleServer.address")
+    private String singleServerAddress;
+
+    @Inject(optional = true)
+    @Named("cloudtag.singleServer.port")
+    private Integer singleServerPort;
+
     public boolean useQualifier() {
         return qualifierName != null && !qualifierName.isEmpty()
                 && qualifierValue != null && !qualifierValue.isEmpty();
+    }
+
+    public boolean useSingleServer() {
+        return provider.equals(SINGLE_SERVER_PROVIDER);
     }
 
     public String getProvider() {
@@ -146,4 +159,19 @@ public class Configuration {
         this.asyncIntervalSeconds = asyncIntervalSeconds;
     }
 
+    public String getSingleServerAddress() {
+        return singleServerAddress;
+    }
+
+    public void setSingleServerAddress(String singleServerAddress) {
+        this.singleServerAddress = singleServerAddress;
+    }
+
+    public Integer getSingleServerPort() {
+        return singleServerPort;
+    }
+
+    public void setSingleServerPort(Integer singleServerPort) {
+        this.singleServerPort = singleServerPort;
+    }
 }

--- a/src/main/java/com/github/lukaszbudnik/cloudtag/ConnectionStringBuilder.java
+++ b/src/main/java/com/github/lukaszbudnik/cloudtag/ConnectionStringBuilder.java
@@ -39,12 +39,16 @@ public class ConnectionStringBuilder {
         computeService = computeServiceContext.getComputeService();
     }
 
-    // this method is mocked in unit tests
     Set<? extends ComputeMetadata> listNodes() {
         return computeService.listNodes();
     }
 
     public String getConnectionString() {
+
+        if (configuration.useSingleServer()) {
+            return configuration.getSingleServerAddress() + ":" + configuration.getSingleServerPort();
+        }
+
         Set<? extends ComputeMetadata> nodes = listNodes();
         FluentIterable<String> connectionStrings = FluentIterable
                 .from(nodes)

--- a/src/test/java/com/github/lukaszbudnik/cloudtag/ConnectionStringBuilderSingleServerTest.java
+++ b/src/test/java/com/github/lukaszbudnik/cloudtag/ConnectionStringBuilderSingleServerTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+package com.github.lukaszbudnik.cloudtag;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConnectionStringBuilderSingleServerTest {
+
+    private static Injector injector;
+
+    @BeforeClass
+    public static void setupClass() {
+        injector = Guice.createInjector(new CloudTagPropertiesModule("/cloudtag_single_server.properties"));
+    }
+
+    @Test
+    public void shouldReturnSingleServerConnectionString() throws Exception {
+        ConnectionStringBuilder connectionStringBuilder = injector.getInstance(ConnectionStringBuilder.class);
+
+        String connectionString = connectionStringBuilder.getConnectionString();
+
+        Assert.assertEquals("192.168.99.100:32773", connectionString);
+    }
+
+}

--- a/src/test/resources/cloudtag_single_server.properties
+++ b/src/test/resources/cloudtag_single_server.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2015 Łukasz Budnik <lukasz.budnik@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+#
+
+cloudtag.provider=single-server
+cloudtag.identity=ABCXXXXXXXXXXXXX
+cloudtag.credential=DEFYYYYYYYYYYY
+cloudtag.tagName=ignored
+cloudtag.tagValue=ignored
+cloudtaq.singleServer.address=192.168.99.100
+cloudtag.singleServer.port=32773


### PR DESCRIPTION
New feature:
- Single server provider - useful for testing and development, when set CloudTag will use a hardcoded single server's address and port
